### PR TITLE
Fix: conversion from BigInt to number is not allowed

### DIFF
--- a/src/chromospyce/__init__.py
+++ b/src/chromospyce/__init__.py
@@ -18,7 +18,7 @@ def from_numpy(nparr):
     """
     This assumes `nparr` is a two-dimensional numpy array with xyz coordinates: [[x,y,z], ...]
     """
-    xyz = nparr
+    xyz = nparr.astype(np.float32)
     # Convert numpy array to pandas dataframe
     xyzDF = pd.DataFrame({'x': xyz[:, 0], 'y': xyz[:, 1], 'z': xyz[:, 2]})
 


### PR DESCRIPTION
Encountered an issue where if we supply chromospyce with a numpy array made up of whole integers (e.g, `[[1, 0, 0], [0, 1, 0]]`) we end up with BigInts  down the line and get the `TypeError: Conversion from 'BigInt' to 'number' is not allowed.` error.

This change simply converts the numpy array passed to the widget to numpy array with dtype of float32. Probably this is not best universally, but at least for now that fixes this issue.